### PR TITLE
fix(Stealmoji): Fix permission check

### DIFF
--- a/plugins/Stealmoji/ui/sheets/AddToServerActionSheet.tsx
+++ b/plugins/Stealmoji/ui/sheets/AddToServerActionSheet.tsx
@@ -33,7 +33,7 @@ export function showAddToServerActionSheet(emojiNode: EmojiNode) {
 function AddToServer({ emojiNode }: { emojiNode: EmojiNode }) {
     // Get guilds as a Array of ID and value pairs, and filter out guilds the user can't edit emojis in
     const guilds = Object.values(GuildStore.getGuilds())
-        .filter(guild => PermissionsStore.can(constants.Permissions.MANAGE_GUILD_EXPRESSIONS, guild))
+        .filter(guild => PermissionsStore.can(constants.Permissions.CREATE_GUILD_EXPRESSIONS, guild))
         .sort((a,b) => a.name?.localeCompare?.(b.name));
 
     return (


### PR DESCRIPTION
fixes permission check to ``CREATE_GUILD_EXPRESSIONS`` since that is the correct perm for adding emojis. ``MANAGE_GUILD_EXPRESSIONS`` is for editing/deleting emojis/stickers
https://docs.discord.com/developers/topics/permissions#permissions